### PR TITLE
Correct the link to Mailinglist on the About page

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -30,6 +30,6 @@ Modern tools such as the Git version control system, Jupyter notebooks and Docke
 We want to meet at regular intervals and inform each other about current projects and methods in the field of data analysis and statistics.
 Furthermore, we will organize seminars, workshops and other events e.g. at the Graduate Academy at the University of Rostock or with experts in the topics of ORDS.
 
-[*Join the ORDS-MV Mailinglist*](https://www.listserv.dfn.de/sympa/subscribe/ords-m)
+[*Join the ORDS-MV Mailinglist*](https://www.listserv.dfn.de/sympa/subscribe/ords-mv)
 
 


### PR DESCRIPTION
The link to "Join the ORDS-MV Mailinglist" on the About page does not work. I replaced "ords-m" with "ords-mv" in the link, which appears to fix the problem and lead to the correct mailing list.